### PR TITLE
fix: added null check after section key

### DIFF
--- a/lib/src/repository.dart
+++ b/lib/src/repository.dart
@@ -112,7 +112,7 @@ class LocalizationRepository {
     String fallbackText,
   ) {
     try {
-      return _sectionsMap?[sectionKey][textKey] ?? fallbackText;
+      return _sectionsMap?[sectionKey]?[textKey] ?? fallbackText;
     } catch (e, s) {
       print(e);
       print(s);


### PR DESCRIPTION
If you try to get a `textKey` and the section key is null a `noSuchMethod` error would occur